### PR TITLE
Add Favourite Song List Logic

### DIFF
--- a/iOS/Source/Hertz 87.9/Hertz 87.9.xcodeproj/project.pbxproj
+++ b/iOS/Source/Hertz 87.9/Hertz 87.9.xcodeproj/project.pbxproj
@@ -31,6 +31,11 @@
 		693147F9204976130094595C /* XSPFTrack.m in Sources */ = {isa = PBXBuildFile; fileRef = 693147F5204976120094595C /* XSPFTrack.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w"; }; };
 		693147FC204976420094595C /* NSMutableString+XSPFKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 693147FA204976420094595C /* NSMutableString+XSPFKit.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w"; }; };
 		693147FE204979A00094595C /* PlaylistControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693147FD204979A00094595C /* PlaylistControllerTest.swift */; };
+		693148012049C9B50094595C /* FavouriteTracksController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693148002049C9B50094595C /* FavouriteTracksController.swift */; };
+		693148032049CC440094595C /* FavouriteSongsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693148022049CC440094595C /* FavouriteSongsControllerTests.swift */; };
+		693148062049DB670094595C /* FavouriteTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693148042049DB630094595C /* FavouriteTrack.swift */; };
+		693148082049DD690094595C /* UserDefaultUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693148072049DD690094595C /* UserDefaultUtilities.swift */; };
+		6931480A2049E1500094595C /* FavouriteTrackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693148092049E1500094595C /* FavouriteTrackTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +83,11 @@
 		693147FA204976420094595C /* NSMutableString+XSPFKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableString+XSPFKit.m"; sourceTree = "<group>"; };
 		693147FB204976420094595C /* NSMutableString+XSPFKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableString+XSPFKit.h"; sourceTree = "<group>"; };
 		693147FD204979A00094595C /* PlaylistControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistControllerTest.swift; sourceTree = "<group>"; };
+		693148002049C9B50094595C /* FavouriteTracksController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavouriteTracksController.swift; sourceTree = "<group>"; };
+		693148022049CC440094595C /* FavouriteSongsControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavouriteSongsControllerTests.swift; sourceTree = "<group>"; };
+		693148042049DB630094595C /* FavouriteTrack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavouriteTrack.swift; sourceTree = "<group>"; };
+		693148072049DD690094595C /* UserDefaultUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultUtilities.swift; sourceTree = "<group>"; };
+		693148092049E1500094595C /* FavouriteTrackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavouriteTrackTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -125,6 +135,9 @@
 				690A1983204800AB004D2734 /* AppDelegate.swift */,
 				690A19A5204800D7004D2734 /* AppContext.swift */,
 				690A19A7204800F4004D2734 /* StreamController.swift */,
+				693148042049DB630094595C /* FavouriteTrack.swift */,
+				693148072049DD690094595C /* UserDefaultUtilities.swift */,
+				693148002049C9B50094595C /* FavouriteTracksController.swift */,
 				690A19AC2048068F004D2734 /* RemoteUrls.swift */,
 				690A19B420480F58004D2734 /* ProgramController.swift */,
 				693147E7204972C70094595C /* PlaylistController.swift */,
@@ -149,7 +162,9 @@
 				690A199A204800AC004D2734 /* Hertz_87_9Tests.swift */,
 				690A199C204800AC004D2734 /* Info.plist */,
 				690A19B62048214E004D2734 /* ProgramTests.swift */,
+				693148092049E1500094595C /* FavouriteTrackTests.swift */,
 				693147FD204979A00094595C /* PlaylistControllerTest.swift */,
+				693148022049CC440094595C /* FavouriteSongsControllerTests.swift */,
 				693147E3204961930094595C /* WebRequestTest.swift */,
 			);
 			path = "Hertz 87.9Tests";
@@ -321,9 +336,12 @@
 				690A1988204800AB004D2734 /* SecondViewController.swift in Sources */,
 				690A19A6204800D7004D2734 /* AppContext.swift in Sources */,
 				693147F7204976130094595C /* XSPFManager.m in Sources */,
+				693148082049DD690094595C /* UserDefaultUtilities.swift in Sources */,
 				693147F9204976130094595C /* XSPFTrack.m in Sources */,
 				693147FC204976420094595C /* NSMutableString+XSPFKit.m in Sources */,
+				693148012049C9B50094595C /* FavouriteTracksController.swift in Sources */,
 				690A19AF20480A93004D2734 /* WebRequestManager.swift in Sources */,
+				693148062049DB670094595C /* FavouriteTrack.swift in Sources */,
 				690A19AD2048068F004D2734 /* RemoteUrls.swift in Sources */,
 				690A1984204800AB004D2734 /* AppDelegate.swift in Sources */,
 				693147F8204976130094595C /* XSPFPlaylist.m in Sources */,
@@ -338,7 +356,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				693147E4204961930094595C /* WebRequestTest.swift in Sources */,
+				693148032049CC440094595C /* FavouriteSongsControllerTests.swift in Sources */,
 				693147FE204979A00094595C /* PlaylistControllerTest.swift in Sources */,
+				6931480A2049E1500094595C /* FavouriteTrackTests.swift in Sources */,
 				690A19B72048214E004D2734 /* ProgramTests.swift in Sources */,
 				690A199B204800AC004D2734 /* Hertz_87_9Tests.swift in Sources */,
 			);

--- a/iOS/Source/Hertz 87.9/Hertz 87.9/FavouriteTrack.swift
+++ b/iOS/Source/Hertz 87.9/Hertz 87.9/FavouriteTrack.swift
@@ -1,0 +1,71 @@
+//  Copyright © 2018 Hertz 87.9. All rights reserved.
+
+import Foundation
+
+protocol PropertyListReadable {
+  func propertyListRepresentation() -> NSDictionary
+  init?(propertyListRepresentation: NSDictionary?)
+}
+
+struct FavouriteTrack {
+  var title: String?
+  var author: String?
+  var timeStamp: Date?
+
+  init(track: XSPFTrack) {
+    self.title = track.title
+    self.author = track.author
+    self.timeStamp = track.timeStamp
+  }
+}
+
+extension FavouriteTrack: Equatable {
+  static func == (lhs: FavouriteTrack, rhs: FavouriteTrack) -> Bool {
+    return lhs.author == rhs.author &&
+      lhs.title == rhs.title &&
+      lhs.timeStamp == rhs.timeStamp
+  }
+}
+
+extension FavouriteTrack: PropertyListReadable {
+
+  init(data: NSDictionary) {
+    // swiftlint:disable:next force_cast
+    let representation = data as! [String: AnyObject]
+    if let title = representation["title"] as? String {
+      self.title = title
+    }
+    if let author = representation["author"] as? String {
+      self.author = author
+    }
+    if let timeStamp = representation["timestamp"] as? Date {
+      self.timeStamp = timeStamp
+    }
+  }
+
+  func propertyListRepresentation() -> NSDictionary {
+    var representation = [String: AnyObject]()
+    if let author = self.author {
+      representation["author"] = author as AnyObject
+    }
+    if let title = self.title {
+      representation["title"] = title as AnyObject
+    }
+    if let timestamp = self.timeStamp {
+      representation["timestamp"] = timestamp as AnyObject
+    }
+    return representation as NSDictionary
+  }
+
+  init?(propertyListRepresentation: NSDictionary?) {
+    guard let values = propertyListRepresentation
+      else {return nil}
+    self =  FavouriteTrack(data: values)
+  }
+}
+
+extension XSPFTrack {
+  var favouriteTrack: FavouriteTrack {
+    return FavouriteTrack(track: self)
+  }
+}

--- a/iOS/Source/Hertz 87.9/Hertz 87.9/FavouriteTracksController.swift
+++ b/iOS/Source/Hertz 87.9/Hertz 87.9/FavouriteTracksController.swift
@@ -1,0 +1,48 @@
+//  Copyright © 2018 Hertz 87.9. All rights reserved.
+
+import Foundation
+
+protocol FavouriteTracksDelegate: class {
+  func songsUpdated()
+}
+
+class FavouriteTracksController {
+  public static let kSongKey = "FavouriteSongs"
+  var songs: [FavouriteTrack]!
+  weak var delegate: FavouriteTracksDelegate?
+
+  init() {
+    if let data = UserDefaults.standard.object(
+      forKey: FavouriteTracksController.kSongKey) as? [AnyObject] {
+      let decodedSongs: [FavouriteTrack] = UserDefaultsUtilities.extractValuesFromPropertyListArray(
+        propertyListArray: data)
+      self.songs = decodedSongs
+    } else {
+      self.songs = [FavouriteTrack]()
+    }
+  }
+
+  func addTrack(track: XSPFTrack) {
+    let encodableTrack = FavouriteTrack(track: track)
+    songs.insert(encodableTrack, at: 0)
+    delegate?.songsUpdated()
+    save()
+  }
+
+  func deleteTrack(at index: Int) {
+    songs.remove(at: index)
+    delegate?.songsUpdated()
+    save()
+  }
+
+  func deleteAll() {
+    songs.removeAll()
+    delegate?.songsUpdated()
+    save()
+  }
+
+  private func save() {
+    UserDefaultsUtilities.saveValuesToDefaults(newValues: songs, key: FavouriteTracksController.kSongKey)
+    UserDefaults.standard.synchronize()
+  }
+}

--- a/iOS/Source/Hertz 87.9/Hertz 87.9/PlaylistController.swift
+++ b/iOS/Source/Hertz 87.9/Hertz 87.9/PlaylistController.swift
@@ -18,10 +18,19 @@ typealias CurrentTitleCompletionHandler = (CurrentSong?, Error?) -> Void
 
 extension XSPFTrack {
   var timeStamp: Date? {
-    guard let time = self.meta[0] as? String else { return nil }
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZ"
-    return dateFormatter.date(from: time)!
+    get {
+      if self.meta.count == 0 { return nil }
+      guard let time = self.meta[0] as? String else { return nil }
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZ"
+      return dateFormatter.date(from: time)!
+    }
+    set {
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZ"
+      let dateString = newValue != nil ? dateFormatter.string(from: newValue!) : ""
+      self.meta[0] = dateString
+    }
   }
 }
 

--- a/iOS/Source/Hertz 87.9/Hertz 87.9/UserDefaultUtilities.swift
+++ b/iOS/Source/Hertz 87.9/Hertz 87.9/UserDefaultUtilities.swift
@@ -1,0 +1,17 @@
+//  Created by Matthias Frick on 02.03.2018.
+
+import Foundation
+
+struct UserDefaultsUtilities {
+
+  static func extractValuesFromPropertyListArray<T: PropertyListReadable>(propertyListArray: [AnyObject]?) -> [T] {
+    guard let encodedArray = propertyListArray
+      else {return []}
+    return encodedArray.map { $0 as? NSDictionary}.flatMap { T(propertyListRepresentation: $0) }
+  }
+
+  static func saveValuesToDefaults<T: PropertyListReadable>(newValues: [T], key: String) {
+    let encodedValues = newValues.map { $0.propertyListRepresentation() }
+    UserDefaults.standard.set(encodedValues, forKey: key)
+  }
+}

--- a/iOS/Source/Hertz 87.9/Hertz 87.9Tests/FavouriteSongsControllerTests.swift
+++ b/iOS/Source/Hertz 87.9/Hertz 87.9Tests/FavouriteSongsControllerTests.swift
@@ -1,0 +1,52 @@
+//  Copyright © 2018 Hertz 87.9. All rights reserved.
+
+import XCTest
+@testable import Hertz_87_9
+
+class FavouriteSongsControllerTests: XCTestCase {
+
+  var favSongsController: FavouriteTracksController!
+
+  override func setUp() {
+    super.setUp()
+    // Reset User Defaults
+    UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+    UserDefaults.standard.synchronize()
+    favSongsController = FavouriteTracksController()
+  }
+
+  func testNewControllerReturnsNotNilList() {
+    XCTAssertNotNil(favSongsController.songs)
+  }
+
+  func testAddSongs() {
+    let trackOne = XSPFTrack()
+    trackOne.author = "Test One"
+    let trackTwo = XSPFTrack()
+    trackTwo.author = "Test Two"
+
+    favSongsController.addTrack(track: trackOne)
+    favSongsController.addTrack(track: trackTwo)
+
+    XCTAssertEqual(favSongsController.songs.count, 2)
+    XCTAssertEqual(favSongsController.songs[0], trackTwo.favouriteTrack)
+    XCTAssertEqual(favSongsController.songs[1], trackOne.favouriteTrack)
+  }
+
+  func testPersistence() {
+    let trackOne = XSPFTrack()
+    trackOne.author = "Test One"
+    let trackTwo = XSPFTrack()
+    trackTwo.author = "Test Two"
+
+    favSongsController.addTrack(track: trackOne)
+    favSongsController.addTrack(track: trackTwo)
+    XCTAssertEqual(favSongsController.songs.count, 2)
+
+    // Reset the controller
+    favSongsController = FavouriteTracksController()
+    XCTAssertEqual(favSongsController.songs.count, 2)
+    XCTAssertEqual(favSongsController.songs[0], trackTwo.favouriteTrack)
+    XCTAssertEqual(favSongsController.songs[1], trackOne.favouriteTrack)
+  }
+}

--- a/iOS/Source/Hertz 87.9/Hertz 87.9Tests/FavouriteTrackTests.swift
+++ b/iOS/Source/Hertz 87.9/Hertz 87.9Tests/FavouriteTrackTests.swift
@@ -1,0 +1,27 @@
+//  Copyright © 2018 Hertz 87.9. All rights reserved.
+
+import XCTest
+@testable import Hertz_87_9
+
+class FavouriteTrackTests: XCTestCase {
+
+  override func setUp() {
+    super.setUp()
+  }
+
+  func testConversionFromXSPFTrack() {
+    let xspfTrack = XSPFTrack()
+    let date = Date()
+    xspfTrack.title = "Title"
+    xspfTrack.author = "Author"
+    xspfTrack.timeStamp = date
+
+    let favTrack = FavouriteTrack(track: xspfTrack)
+
+    XCTAssertEqual(favTrack.title, xspfTrack.title)
+    XCTAssertEqual(favTrack.author, xspfTrack.author)
+    XCTAssertEqual(favTrack.timeStamp, xspfTrack.timeStamp)
+
+    XCTAssertEqual(xspfTrack.favouriteTrack, favTrack)
+  }
+}


### PR DESCRIPTION
This PR adds the logic for handling the favourite lists of songs.
This is a first step and still lacks some functionality for later (like sending all your songs as an email in plain text).